### PR TITLE
Preserving 3rd party comments

### DIFF
--- a/examples/MyClassExample.php
+++ b/examples/MyClassExample.php
@@ -6,8 +6,13 @@ namespace Example;
 use PUGX\AOP\Aspect\Loggable\Annotation as Log;
 use PUGX\AOP\Aspect\Roulette\Annotation as Roulette;
 
-// now, lets say that I have this class, I enabled Loggable in the constructor and
-// the doSomething method
+/**
+ * now, lets say that I have this class, I enabled Loggable in the constructor and
+ * the doSomething method
+ *
+ * @\PUGX\AOP\Stub\MyAnnotation
+ * @link https://github.com/PUGX/aop the aop project homepage
+ */
 class MyExampleClass
 {
     protected $a;
@@ -26,6 +31,7 @@ class MyExampleClass
      * @Log(what="$c", when="start", with="monolog.logger_standard", as="argument $c is %s")
      * @Log(what="$this->b", when="start", with="monolog.logger_standard", as="Hey, value of MyExampleClass::b is %s")
      * @Log(what="$this->b", when="end", with="monolog.logger_standard", as="HOLY COW! Now MyExampleClass::b is %s")
+     * @\PUGX\AOP\Stub\MyAnnotation
      */
     public function doSomething($c)
     {

--- a/src/PUGX/AOP/ProxyGenerator.php
+++ b/src/PUGX/AOP/ProxyGenerator.php
@@ -73,8 +73,9 @@ class ProxyGenerator extends AbstractClassGenerator
                 ->writeln(' * This code was generated automatically by the CG library, manual changes to it')
                 ->writeln(' * will be lost upon next generation.')
                 ->writeln(' */')
+                ->writeln('')
             ;
-            $docBlock = $writer->getContent();
+            $docBlock = $writer->getContent() . $this->class->getDocComment() ."\n";
         }
 
         $this->generatedClass = PhpClass::create()

--- a/test/PUGX/AOP/Stub/MyAnnotation.php
+++ b/test/PUGX/AOP/Stub/MyAnnotation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PUGX\AOP\Stub;
+
+/**
+ * Dummy not aspected Annotation
+ *
+ * @author Kpacha <kpacha666@gmail.com>
+ *
+ * @Annotation
+ */
+class MyAnnotation
+{
+
+    private $value;
+
+    public function __construct($value = null)
+    {
+        $this->value = $value;
+    }
+
+}

--- a/test/PUGX/AOP/Stub/MyClass.php
+++ b/test/PUGX/AOP/Stub/MyClass.php
@@ -6,6 +6,12 @@ use \PUGX\AOP\Aspect\Loggable\Annotation as Log;
 use \PUGX\AOP\Aspect\Roulette\Annotation as Roulette;
 use \stdClass;
 
+/**
+ * Some doc comments here!
+ *
+ * @MyAnnotation
+ * @link https://github.com/PUGX/aop the aop project homepage
+ */
 class MyClass
 {
     protected $a;
@@ -28,6 +34,7 @@ class MyClass
 
     /**
      * @Roulette(probability="1")
+     * @MyAnnotation
      * @param stdClass $o
      */
     public function randomError(stdClass $o)


### PR DESCRIPTION
Let's say we want to use some no-AOP annotations in our code (maybe, you want to use some filters from a 3rd party lib). If the enhaced proxy removes the class-level and method-level docblocks, maybe the 3rd party doesn't work as expected, so why should them be removed?

This implementation just takes the original docBlocks, removes the already processed annotations (related with any enhaced aspect) and adds the docBlocks to the enhaced proxy class.
