### PR TITLE
Inspecting parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
         "symfony/class-loader": "2.2.*",
         "psr/log": "1.0.0",
         "doctrine/common": "2.3.*",
-        "jms/cg": "1.1.*@dev"
+        "jms/cg": "1.1.*@dev",
+        "respect/validation": "0.4.4"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/examples/MyClassExample.php
+++ b/examples/MyClassExample.php
@@ -6,8 +6,13 @@ namespace Example;
 use PUGX\AOP\Aspect\Loggable\Annotation as Log;
 use PUGX\AOP\Aspect\Roulette\Annotation as Roulette;
 
-// now, lets say that I have this class, I enabled Loggable in the constructor and
-// the doSomething method
+/**
+ * now, lets say that I have this class, I enabled Loggable in the constructor and
+ * the doSomething method
+ *
+ * @\PUGX\AOP\Stub\MyAnnotation
+ * @link https://github.com/PUGX/aop the aop project homepage
+ */
 class MyExampleClass
 {
     protected $a;
@@ -26,6 +31,7 @@ class MyExampleClass
      * @Log(what="$c", when="start", with="monolog.logger_standard", as="argument $c is %s")
      * @Log(what="$this->b", when="start", with="monolog.logger_standard", as="Hey, value of MyExampleClass::b is %s")
      * @Log(what="$this->b", when="end", with="monolog.logger_standard", as="HOLY COW! Now MyExampleClass::b is %s")
+     * @\PUGX\AOP\Stub\MyAnnotation
      */
     public function doSomething($c)
     {

--- a/src/PUGX/AOP/Aspect/AspectInterface.php
+++ b/src/PUGX/AOP/Aspect/AspectInterface.php
@@ -21,7 +21,7 @@ interface AspectInterface
      * @param $instance
      * @param $methodName
      * @param array $arguments
-     * @return void
+     * @return mixed
      */
     public function trigger(BaseAnnotation $annotation, $instance, $methodName, array $arguments);
 }

--- a/src/PUGX/AOP/Aspect/BaseAnnotation.php
+++ b/src/PUGX/AOP/Aspect/BaseAnnotation.php
@@ -11,6 +11,7 @@ class BaseAnnotation extends DoctrineAnnotation
 {
 
     const START = 'start';
+    const VALIDATION = 'validation';
     const END = 'end';
 
     public $when = self::START;
@@ -36,6 +37,16 @@ class BaseAnnotation extends DoctrineAnnotation
     public function getAspectName()
     {
         return $this->_aspectName;
+    }
+
+    /**
+     * Get the parameter to be inspected by the aspect service.
+     *
+     * @return null
+     */
+    public function getParameterToInspect()
+    {
+        return null;
     }
 
 }

--- a/src/PUGX/AOP/Aspect/Roulette/Annotation.php
+++ b/src/PUGX/AOP/Aspect/Roulette/Annotation.php
@@ -13,7 +13,7 @@ class Annotation extends BaseAnnotation
 {
 
     public $probability = 0.5;
-    public $exception = '\Exception';
+    public $exception = 'PUGX\AOP\Exception';
     public $message = 'Random error dispatched from Roulette aspect';
     protected $_aspectName = 'Roulette';
 

--- a/src/PUGX/AOP/Aspect/Validator/Annotation.php
+++ b/src/PUGX/AOP/Aspect/Validator/Annotation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PUGX\AOP\Aspect\Validator;
+
+use PUGX\AOP\Aspect\BaseAnnotation;
+
+/**
+ * Annotation class for the Loggable aspect.
+ * 
+ * @Annotation
+ */
+class Annotation extends BaseAnnotation
+{
+
+    const POSITIVE = 0;
+    const NEGATIVE = 1;
+    const ZERO = 2;
+    const NULL = 3;
+    const NOT_NULL = 4;
+
+    protected $_aspectName = 'Validator';
+    public $when = self::VALIDATION;
+    public $parameter = '';
+    public $value = self::NOT_NULL;
+
+    /**
+     * Get the name of the parameter to inspect
+     *
+     * @return string
+     */
+    public function getParameterToInspect()
+    {
+        return $this->parameter;
+    }
+
+}

--- a/src/PUGX/AOP/Aspect/Validator/Validator.php
+++ b/src/PUGX/AOP/Aspect/Validator/Validator.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace PUGX\AOP\Aspect\Validator;
+
+use PUGX\AOP\Aspect\AspectInterface,
+    PUGX\AOP\Aspect\BaseAnnotation;
+use Respect\Validation\Validator as v;
+
+class Validator implements AspectInterface
+{
+
+    private $container;
+
+    function __construct($container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function trigger(BaseAnnotation $annotation, $instance, $methodName, array $arguments)
+    {
+        $parameterToInspect = $annotation->getParameterToInspect();
+        $reflMethod = new \ReflectionMethod($instance->getSubjectClass(), $methodName);
+        foreach ($reflMethod->getParameters() as $key => $parameter) {
+            if ($parameter->name == $parameterToInspect) {
+                return $this->validate($annotation, $arguments[$key]);
+            }
+        }
+        throw new \Exception($parameterToInspect . ' not found!');
+    }
+
+    protected function validate($annotation, $value)
+    {
+        if (!$this->getValidator($annotation->value)->validate($value)) {
+            throw new \Exception('The parameter [' . $annotation->getParameterToInspect() . "] has an invalid value [$value]");
+        }
+    }
+    
+    protected function getValidator($validationType)
+    {
+        switch($validationType){
+            case Annotation::POSITIVE:
+                return v::numeric()->positive();
+                break;
+            case Annotation::NEGATIVE:
+                return v::numeric()->negative();
+                break;
+            case Annotation::ZERO:
+                return v::numeric()->equals(0);
+                break;
+            case Annotation::NULL:
+                return v::equals(null);
+                break;
+            case Annotation::NOT_NULL:
+                return v::not(v::equals(null));
+                break;
+        }
+        throw new \Exception('Validator not found!');
+    }
+
+}

--- a/src/PUGX/AOP/Aspect/Validator/Validator.php
+++ b/src/PUGX/AOP/Aspect/Validator/Validator.php
@@ -3,7 +3,8 @@
 namespace PUGX\AOP\Aspect\Validator;
 
 use PUGX\AOP\Aspect\AspectInterface,
-    PUGX\AOP\Aspect\BaseAnnotation;
+    PUGX\AOP\Aspect\BaseAnnotation,
+    PUGX\AOP\Exception;
 use Respect\Validation\Validator as v;
 
 class Validator implements AspectInterface
@@ -28,13 +29,13 @@ class Validator implements AspectInterface
                 return $this->validate($annotation, $arguments[$key]);
             }
         }
-        throw new \Exception($parameterToInspect . ' not found!');
+        throw new Exception($parameterToInspect . ' not found!');
     }
 
     protected function validate($annotation, $value)
     {
         if (!$this->getValidator($annotation->value)->validate($value)) {
-            throw new \Exception('The parameter [' . $annotation->getParameterToInspect() . "] has an invalid value [$value]");
+            throw new Exception('The parameter [' . $annotation->getParameterToInspect() . "] has an invalid value [$value]");
         }
     }
     
@@ -57,7 +58,7 @@ class Validator implements AspectInterface
                 return v::not(v::equals(null));
                 break;
         }
-        throw new \Exception('Validator not found!');
+        throw new Exception('Validator not found!');
     }
 
 }

--- a/src/PUGX/AOP/AspectCodeGenerator.php
+++ b/src/PUGX/AOP/AspectCodeGenerator.php
@@ -79,14 +79,16 @@ class AspectCodeGenerator
      * @param string $aspectName
      * @param string $annotationClass
      * @param string $annotationParams
+     * @param string|null $parameter
      * @return String
      */
-    public function generateAspectCode($aspectName, $annotationClass, $annotationParams)
+    public function generateAspectCode($aspectName, $annotationClass, $annotationParams, $parameter = null)
     {
+        $finalAction = ($parameter) ? '$'.$parameter.' =' : 'return';
         return sprintf(
-                        'if(($result = $this->%s->trigger(new \%s(array(%s)), $this, \'%s\', array(%s))) !== null) return $result;',
+                        'if(($result = $this->%s->trigger(new \%s(array(%s)), $this, \'%s\', array(%s))) !== null) %s $result;',
                         $this->getAspectPropertyName($aspectName), $annotationClass, $annotationParams,
-                        $this->methodName, $this->params
+                        $this->methodName, $this->params, $finalAction
         );
     }
 

--- a/src/PUGX/AOP/AspectCodeGenerator.php
+++ b/src/PUGX/AOP/AspectCodeGenerator.php
@@ -57,8 +57,7 @@ class AspectCodeGenerator
     public function generateReflectionDeclarationCode()
     {
         return sprintf(
-                        '$reflection = new \ReflectionMethod(%s, %s);',
-                        var_export(ClassUtils::getUserClass($this->className), true),
+                        '$reflection = new \ReflectionMethod($this->_subjectClass, %s);',
                         var_export($this->methodName, true)
         );
     }

--- a/src/PUGX/AOP/AspectGenerator.php
+++ b/src/PUGX/AOP/AspectGenerator.php
@@ -139,9 +139,10 @@ class AspectGenerator implements GeneratorInterface
 
         $aspectedMethod = new AspectedMethod;
         $aspectedMethod->addCode($generator->generateReflectionDeclarationCode(), AspectedMethod::DECLARATION);
-        $aspectedMethod->setCode($implementedAspects['before'], AspectedMethod::BEFORE);
+        $aspectedMethod->setCode($implementedAspects[AspectedMethod::BEFORE], AspectedMethod::BEFORE);
         $aspectedMethod->addCode($generator->generateReflectionInvocationCode(), AspectedMethod::EXECUTION);
-        $aspectedMethod->setCode($implementedAspects['after'], AspectedMethod::AFTER);
+        $aspectedMethod->setCode($implementedAspects[AspectedMethod::VALIDATION], AspectedMethod::VALIDATION);
+        $aspectedMethod->setCode($implementedAspects[AspectedMethod::AFTER], AspectedMethod::AFTER);
         $aspectedMethod->addCode($generator->generateReturningCode(), AspectedMethod::RETURNING);
 
         if ($method->name === '__construct') {

--- a/src/PUGX/AOP/AspectedMethod.php
+++ b/src/PUGX/AOP/AspectedMethod.php
@@ -13,13 +13,15 @@ class AspectedMethod
     const DECLARATION = 1;
     const INJECTION = 0;
     const BEFORE = 2;
-    const EXECUTION = 3;
-    const AFTER = 4;
-    const RETURNING = 5;
+    const VALIDATION = 3;
+    const EXECUTION = 4;
+    const AFTER = 5;
+    const RETURNING = 6;
 
     private static $stages = array(
         self::DECLARATION => 'Declaration',
         self::INJECTION => 'Injection',
+        self::VALIDATION => 'Validation',
         self::BEFORE => 'Before',
         self::EXECUTION => 'Execution',
         self::AFTER => 'After',

--- a/src/PUGX/AOP/ProxyGenerator.php
+++ b/src/PUGX/AOP/ProxyGenerator.php
@@ -73,8 +73,9 @@ class ProxyGenerator extends AbstractClassGenerator
                 ->writeln(' * This code was generated automatically by the CG library, manual changes to it')
                 ->writeln(' * will be lost upon next generation.')
                 ->writeln(' */')
+                ->writeln('')
             ;
-            $docBlock = $writer->getContent();
+            $docBlock = $writer->getContent() . $this->class->getDocComment() ."\n";
         }
 
         $this->generatedClass = PhpClass::create()

--- a/test/PUGX/AOP/Stub/MyAnnotation.php
+++ b/test/PUGX/AOP/Stub/MyAnnotation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PUGX\AOP\Stub;
+
+/**
+ * Dummy not aspected Annotation
+ *
+ * @author Kpacha <kpacha666@gmail.com>
+ *
+ * @Annotation
+ */
+class MyAnnotation
+{
+
+    private $value;
+
+    public function __construct($value = null)
+    {
+        $this->value = $value;
+    }
+
+}

--- a/test/PUGX/AOP/Stub/MyClass.php
+++ b/test/PUGX/AOP/Stub/MyClass.php
@@ -4,6 +4,7 @@ namespace PUGX\AOP\Stub;
 
 use \PUGX\AOP\Aspect\Loggable\Annotation as Log;
 use \PUGX\AOP\Aspect\Roulette\Annotation as Roulette;
+use PUGX\AOP\Aspect\Validator\Annotation as Validator;
 use \stdClass;
 
 /**
@@ -40,5 +41,15 @@ class MyClass
     public function randomError(stdClass $o)
     {
         return $o;
+    }
+
+    /**
+     * @Validator(parameter="a",value=Validator::POSITIVE)
+     * @param float $a
+     * @return float
+     */
+    public function getSquareRoot($a)
+    {
+        return sqrt($a);
     }
 }

--- a/test/PUGX/AOP/Stub/MyClass.php
+++ b/test/PUGX/AOP/Stub/MyClass.php
@@ -6,6 +6,12 @@ use \PUGX\AOP\Aspect\Loggable\Annotation as Log;
 use \PUGX\AOP\Aspect\Roulette\Annotation as Roulette;
 use \stdClass;
 
+/**
+ * Some doc comments here!
+ *
+ * @MyAnnotation
+ * @link https://github.com/PUGX/aop the aop project homepage
+ */
 class MyClass
 {
     protected $a;
@@ -28,6 +34,7 @@ class MyClass
 
     /**
      * @Roulette(probability="1")
+     * @MyAnnotation
      * @param stdClass $o
      */
     public function randomError(stdClass $o)

--- a/test/PUGX/AOP/Test/MainTest.php
+++ b/test/PUGX/AOP/Test/MainTest.php
@@ -33,7 +33,7 @@ class MainTest extends TestCase
     }
 
     /**
-     * @expectedException        \Exception
+     * @expectedException        \PUGX\AOP\Exception
      * @expectedExceptionMessage Random error dispatched from Roulette aspect
      */
     public function testSimpleRoulette()
@@ -42,7 +42,7 @@ class MainTest extends TestCase
     }
 
     /**
-     * @expectedException        \Exception
+     * @expectedException        \PUGX\AOP\Exception
      * @expectedExceptionMessage The parameter [a] has an invalid value [-1]
      */
     public function testSimpleValidator()

--- a/test/container.yml
+++ b/test/container.yml
@@ -7,6 +7,9 @@ services:
   roulette:
     class: "PUGX\\AOP\\Aspect\\Roulette\\Roulette"
     arguments: ["@service_container"]
+  validator:
+    class: "PUGX\\AOP\\Aspect\\Validator\\Validator"
+    arguments: ["@service_container"]
   monolog.logger_standard:
     class: "Monolog\\Logger"
     arguments:


### PR DESCRIPTION
I added a new stage between 'Before' and 'Execution' where the aspect execution could inspect and alter a parameter. I called this stage 'Validation' but I think 'Inspection' or 'Enforce' would be more accurated. That's because the aspects triggered here could return a value to replace the original value of the inspected parameter.

The enhaced code for 

```
/**
 * @Validator(parameter="a",value=Validator::POSITIVE)
 */
public function getSquareRoot($a)
```

is like this:

```
public function getSquareRoot($a)
{
    ...

    // Validation stage
    if(($result = $this->__CG_PUGX_AOP__aspectValidator->trigger(new \PUGX\AOP\Aspect\Validator\Annotation(array('when' => 'validation', 'parameter' => 'a', 'value' => '0')), $this, 'getSquareRoot', array($a))) !== null) $a = $result;

    ...

}
```

With this stage you could inspect and enforce the parameter value, without changing the method implementation. You can imagine some kind of Fail Fast aspect (like the Validator one) or an adapter to fit some new requirements not implemented yet in the clients (say your API has change and you can not force your clients to be updated)
